### PR TITLE
Feat/#3 - 기본 Entity 구현 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ build/
 !**/src/test/**/build/
 
 *.yml
-
+*.yaml
 ### STS ###
 .apt_generated
 .classpath

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM khipu/openjdk17-alpine:latest
+ARG JAR_FILE_PATH=kream/build/libs/kream-0.0.1-SNAPSHOT.jar
+COPY ${JAR_FILE_PATH} app.jar
+ENTRYPOINT ["java", "-jar", "app.jar"]
+EXPOSE 8080
+EXPOSE 5432
+#RUN sudo apt update
+#ENTRYPOINT ["java","-jar","demo-0.0.1-SNAPSHOT.jar"]
+
+
+

--- a/src/main/java/com/app/kream/domain/BaseTimeEntity.java
+++ b/src/main/java/com/app/kream/domain/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package com.app.kream.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createAt;
+
+    @LastModifiedDate
+    private LocalDateTime updateAt;
+
+}

--- a/src/main/java/com/app/kream/domain/Member.java
+++ b/src/main/java/com/app/kream/domain/Member.java
@@ -1,4 +1,27 @@
 package com.app.kream.domain;
 
-public class Member {
+import jakarta.persistence.*;
+import lombok.*;
+
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class Member extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter
+    @Column(nullable = false)
+    private String name;
+
+    @Setter
+    @Column(nullable = false)
+    private int age;
 }

--- a/src/main/java/com/app/kream/domain/Product.java
+++ b/src/main/java/com/app/kream/domain/Product.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class Product extends BaseTimeEntity{
+public class Product extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -39,5 +39,21 @@ public class Product extends BaseTimeEntity{
 
     @Column(nullable = false)
     private String styleCount;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ProductStatus status;
+
+    @Column(nullable = false)
+    private String transactionCount;
+
+    @Column(nullable = false)
+    private String mentionCount;
+
+    @Column(nullable = false)
+    private String brandTtitle;
+
+    @Column(nullable = false)
+    private boolean isFast;
 
 }

--- a/src/main/java/com/app/kream/domain/Product.java
+++ b/src/main/java/com/app/kream/domain/Product.java
@@ -1,4 +1,43 @@
 package com.app.kream.domain;
 
-public class Product {
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Product extends BaseTimeEntity{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String thumbnailUrl;
+
+    @Column(nullable = false)
+    private String price;
+
+    @Column(nullable = false)
+    private String engTitle;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String recentPrice;
+
+    @Column(nullable = false)
+    private String variablePrice;
+
+    @Column(nullable = false)
+    private String variablePercent;
+
+    @Column(nullable = false)
+    private String styleCount;
+
 }

--- a/src/main/java/com/app/kream/domain/ProductStatus.java
+++ b/src/main/java/com/app/kream/domain/ProductStatus.java
@@ -1,0 +1,5 @@
+package com.app.kream.domain;
+
+public enum ProductStatus {
+    UPDATE,NEW,BASIC
+}

--- a/src/main/java/com/app/kream/domain/StyleImage.java
+++ b/src/main/java/com/app/kream/domain/StyleImage.java
@@ -1,6 +1,5 @@
 package com.app.kream.domain;
 
-
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,14 +11,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class Scrap extends BaseTimeEntity {
+public class StyleImage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)
-    private Long memberId;
+    private String imageUrl;
 
     @Column(nullable = false)
-    private Long productId;
+    private boolean isVideo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Product product;
+
 }

--- a/src/main/java/com/app/kream/repository/StyleImageRepository.java
+++ b/src/main/java/com/app/kream/repository/StyleImageRepository.java
@@ -1,0 +1,7 @@
+package com.app.kream.repository;
+
+import com.app.kream.domain.Scrap;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StyleImageRepository extends JpaRepository<Scrap, Long> {
+}

--- a/src/main/java/com/app/kream/service/StyleImageService.java
+++ b/src/main/java/com/app/kream/service/StyleImageService.java
@@ -1,0 +1,4 @@
+package com.app.kream.service;
+
+public class StyleImageService {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=kream

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://localhost:5432/kream
+    username: postgres
+    password: 12345678
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true


### PR DESCRIPTION
## ✨ 해결한 이슈번호
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- closes: #3 

## 📋 요구사항 분석
<!-- 해당 API에 대한 요구사항(사용자 플로우)을/를 설명해주세요 -->
- [x] Member
- [x] Product
- [x] Scrap
- [x] StyleImage

## 📢 주요 코드 설명
<!-- 해당 PR에서 공유해야하는 부분이나, 특별히 리뷰어가 확인해야하는 코드가 있다면 코드와 함께 공유해주세요 -->
[ERD CLOUD](https://www.erdcloud.com/d/rZLFMPnQs4y3k9YKo)
## 전체 구조
![image](https://github.com/NOW-SOPT-APP4-KREAM/KREAM-Server/assets/40743105/7bf2d159-7ad7-4ebc-8c01-11c1b1ed80d9)

혹시 변경할것이 있다면 말해주세요!
### Member
![image](https://github.com/NOW-SOPT-APP4-KREAM/KREAM-Server/assets/40743105/639aed35-36e1-404c-a5c7-0c9a056db19a)
- 멤버는 가볍게 id랑 이름, 나이만 가지도록 설정했습니다.
- Member는 Scrap쪽에서 MemberId만 가질수 있도록 설계했습니다.
### Scrap
![image](https://github.com/NOW-SOPT-APP4-KREAM/KREAM-Server/assets/40743105/746cf6bd-3368-450c-82b0-9e1a65e9054a)
- Scrap은 누가 무엇을 스크랩했는지 기록합니다.
객체간의 의존성을 굳이 확인할 필요가 없기 때문에 
상대방의 객체자체를 참조하는것이 아닌 비종속적 관계로써 
각 entity의 ID값만을 참조하게 설정했습니다.

#### 왜 ?
스크랩의 여부를 Id만 참조시키면 Member가 처음 조회될때 
Member의 Id값으로 스크랩한 여부를 전부 확인할수있고 
findByID가 아닌 getById로 쿼리여부없이 조회가능한 상황이
만들어질수 있습니다.

### Product
![image](https://github.com/NOW-SOPT-APP4-KREAM/KREAM-Server/assets/40743105/b6f457b2-f341-4f45-8566-e430d210fc00)

일단 Product에  연관되서 보여주는 Image들을 StyleImage라는 도메인으로 분리했습니다.
신발에서 색깔다른것들 있으면 9개보여주는 연관 URL 보내주는 부분을 
외부 이미지 엔티티로 작동하게 설계했습니다.

이유는 
1. 하나의 엔티티에서 너무 다양한 것들을 담당함
2. 리스트로 담아두기엔 메모리 비효율적이라고 생각했습니다.

### StyleImage
![image](https://github.com/NOW-SOPT-APP4-KREAM/KREAM-Server/assets/40743105/f53df0ae-c711-4ddd-a3e4-e8a26800810a)
- 상품의 id를 통해서 image의 값들을 조회하기 위해 Product와 @ManyToOne으로 연관관계 설정을 해주었습니다.


## 📢 PR Point to Reviewers 
- 혹시 변경하고 싶으신 부분이 있으시면 꼭 말해주세요! 
- 언제든지 환영입니다~!
<!-- 리뷰에서 확인해주면 좋겠는 사항이 있다면 작성해주세요. (없으면 지우셔도 됩니다.) -->
