### PR TITLE
Feat/#5 Scarp 등록 API 구현 

### DIFF
--- a/src/main/java/com/app/kream/controller/scrap/ScrapController.java
+++ b/src/main/java/com/app/kream/controller/scrap/ScrapController.java
@@ -2,7 +2,7 @@ package com.app.kream.controller.scrap;
 
 import com.app.kream.common.CommonResponse;
 import com.app.kream.service.ScrapService;
-import com.app.kream.service.dto.ScrapCreateDto;
+import com.app.kream.service.dto.ScrapCreateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -10,10 +10,12 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/scrap")
 public class ScrapController implements ScrapControllerSwagger {
+
     private final ScrapService scrapService;
+
     @PostMapping
     public CommonResponse createScrap(
-           ScrapCreateDto request
+            ScrapCreateRequest request
     ) {
         return scrapService.createScrap(
                 request

--- a/src/main/java/com/app/kream/controller/scrap/ScrapController.java
+++ b/src/main/java/com/app/kream/controller/scrap/ScrapController.java
@@ -1,4 +1,22 @@
 package com.app.kream.controller.scrap;
 
+import com.app.kream.common.CommonResponse;
+import com.app.kream.service.ScrapService;
+import com.app.kream.service.dto.ScrapCreateDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/scrap")
 public class ScrapController implements ScrapControllerSwagger {
+    private final ScrapService scrapService;
+    @PostMapping
+    public CommonResponse createScrap(
+           ScrapCreateDto request
+    ) {
+        return scrapService.createScrap(
+                request
+        );
+    }
 }

--- a/src/main/java/com/app/kream/controller/scrap/ScrapControllerSwagger.java
+++ b/src/main/java/com/app/kream/controller/scrap/ScrapControllerSwagger.java
@@ -1,7 +1,27 @@
 package com.app.kream.controller.scrap;
 
+import com.app.kream.common.CommonResponse;
+import com.app.kream.domain.Scrap;
+import com.app.kream.service.dto.ScrapCreateDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "스크랩", description = "스크랩 관련 API 입니다.")
 public interface ScrapControllerSwagger {
+    @Operation(summary = "세부 상품 조회 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Scarp 생성에 성공했습니다."),
+            @ApiResponse(responseCode = "404",
+                    description = "1. Scrap 생성 실패.\n",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    CommonResponse createScrap(
+            ScrapCreateDto request
+    );
+
 }

--- a/src/main/java/com/app/kream/controller/scrap/ScrapControllerSwagger.java
+++ b/src/main/java/com/app/kream/controller/scrap/ScrapControllerSwagger.java
@@ -1,8 +1,7 @@
 package com.app.kream.controller.scrap;
 
 import com.app.kream.common.CommonResponse;
-import com.app.kream.domain.Scrap;
-import com.app.kream.service.dto.ScrapCreateDto;
+import com.app.kream.service.dto.ScrapCreateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -12,16 +11,17 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "스크랩", description = "스크랩 관련 API 입니다.")
 public interface ScrapControllerSwagger {
-    @Operation(summary = "세부 상품 조회 API")
+    @Operation(summary = "스크랩 상품 등록 API")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Scarp 생성에 성공했습니다."),
-            @ApiResponse(responseCode = "404",
-                    description = "1. Scrap 생성 실패.\n",
-                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            //TODO
+//            @ApiResponse(responseCode = "404",
+//                    description = "1. Scrap 생성 실패.\n"
+//            ),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     })
     CommonResponse createScrap(
-            ScrapCreateDto request
+            ScrapCreateRequest request
     );
 
 }

--- a/src/main/java/com/app/kream/repository/ScrapRepository.java
+++ b/src/main/java/com/app/kream/repository/ScrapRepository.java
@@ -2,6 +2,8 @@ package com.app.kream.repository;
 
 import com.app.kream.domain.Scrap;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ScrapRepository extends JpaRepository<Scrap, Long> {
 }

--- a/src/main/java/com/app/kream/service/ScrapService.java
+++ b/src/main/java/com/app/kream/service/ScrapService.java
@@ -1,4 +1,29 @@
 package com.app.kream.service;
 
+import com.app.kream.common.CommonResponse;
+import com.app.kream.domain.Scrap;
+import com.app.kream.exception.SuccessMessage;
+import com.app.kream.repository.ScrapRepository;
+import com.app.kream.service.dto.ScrapCreateDto;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class ScrapService {
+    private final ScrapRepository scrapRepository;
+
+    @Transactional
+    public CommonResponse createScrap(
+            ScrapCreateDto request
+    ) {
+        Scrap scrap = Scrap.builder()
+                .memberId(request.memberId())
+                .productId(request.productId())
+                .build();
+
+        scrapRepository.save(scrap);
+        return CommonResponse.success(SuccessMessage.PROCESS_SUCCESS);
+    }
 }

--- a/src/main/java/com/app/kream/service/ScrapService.java
+++ b/src/main/java/com/app/kream/service/ScrapService.java
@@ -4,7 +4,7 @@ import com.app.kream.common.CommonResponse;
 import com.app.kream.domain.Scrap;
 import com.app.kream.exception.SuccessMessage;
 import com.app.kream.repository.ScrapRepository;
-import com.app.kream.service.dto.ScrapCreateDto;
+import com.app.kream.service.dto.ScrapCreateRequest;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,7 +16,7 @@ public class ScrapService {
 
     @Transactional
     public CommonResponse createScrap(
-            ScrapCreateDto request
+            ScrapCreateRequest request
     ) {
         Scrap scrap = Scrap.builder()
                 .memberId(request.memberId())

--- a/src/main/java/com/app/kream/service/dto/ScrapCreateDto.java
+++ b/src/main/java/com/app/kream/service/dto/ScrapCreateDto.java
@@ -1,0 +1,13 @@
+package com.app.kream.service.dto;
+
+
+import lombok.Getter;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@Getter
+public record ScrapCreateDto (
+        @RequestHeader Long memberId,
+        @RequestBody Long productId
+) {
+}

--- a/src/main/java/com/app/kream/service/dto/ScrapCreateRequest.java
+++ b/src/main/java/com/app/kream/service/dto/ScrapCreateRequest.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 @Getter
-public record ScrapCreateDto (
+public record ScrapCreateRequest(
         @RequestHeader Long memberId,
         @RequestBody Long productId
 ) {


### PR DESCRIPTION
### PR올려놓고 내일 PR 작성해보겠습니다.ㅠㅅㅠ
## ✨ 해결한 이슈번호
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- closes: #5 

## 📋 요구사항 분석
<!-- 해당 API에 대한 요구사항(사용자 플로우)을/를 설명해주세요 -->
- [ ] 해당 상품을 ProductId와 memberId를 사용해 Scrap Entity를 생성합니다.
- [ ] API 요청에 성공하면 200 response를 return 합니다. 

## 📢 주요 코드 설명
<!-- 해당 PR에서 공유해야하는 부분이나, 특별히 리뷰어가 확인해야하는 코드가 있다면 코드와 함께 공유해주세요 -->
- Controller 구현 부분
- Request로 memberId값과 productId 값을 각각 header와 body에 받는 dto 로 구현했습니다! 
https://github.com/NOW-SOPT-APP4-KREAM/KREAM-Server/blob/094767063941166a1261adf586fbd0738809f4e7/src/main/java/com/app/kream/controller/scrap/ScrapController.java#L17-L24

- Swagger 부분
- 해당 주석 처리부분은 후에 Error 처리 구현할때 넣기 위해 Todo로 주석처리 하였습니다! 
https://github.com/NOW-SOPT-APP4-KREAM/KREAM-Server/blob/094767063941166a1261adf586fbd0738809f4e7/src/main/java/com/app/kream/controller/scrap/ScrapControllerSwagger.java#L12-L27
