### PR TITLE
Feat/#17 상품 검색 API 구현

### DIFF
--- a/src/main/java/com/app/kream/controller/product/ProductController.java
+++ b/src/main/java/com/app/kream/controller/product/ProductController.java
@@ -43,9 +43,9 @@ public class ProductController implements ProductControllerSwagger {
     }
 
     @Override
-    @GetMapping("/{findName}")
-    public CommonResponse<SearchProductResponse> getRecommendProduct(
-            @PathVariable String findName
+    @GetMapping
+    public CommonResponse<SearchProductResponse> getFindProduct(
+            @RequestParam(value = "findName") String findName
     ) {
         return CommonResponse.success(SuccessMessage.GET_FIND_PRODUCT_BY_NAME, productService.findSearchProduct(findName));
     }

--- a/src/main/java/com/app/kream/controller/product/ProductController.java
+++ b/src/main/java/com/app/kream/controller/product/ProductController.java
@@ -6,6 +6,7 @@ import com.app.kream.service.ProductService;
 import com.app.kream.service.dto.DetailProductResponse;
 import com.app.kream.service.dto.RecommendProductResponse;
 import com.app.kream.service.dto.ReleaseProductResponse;
+import com.app.kream.service.dto.SearchProductResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -39,5 +40,13 @@ public class ProductController implements ProductControllerSwagger {
             @RequestHeader final Long memberId
     ) {
         return CommonResponse.success(SuccessMessage.GET_RECOMMEND_PRODUCT_SUCCESS, productService.findRecommendProduct(memberId));
+    }
+
+    @Override
+    @GetMapping("/{findName}")
+    public CommonResponse<SearchProductResponse> getRecommendProduct(
+            @PathVariable String findName
+    ) {
+        return CommonResponse.success(SuccessMessage.GET_FIND_PRODUCT_BY_NAME, productService.findSearchProduct(findName));
     }
 }

--- a/src/main/java/com/app/kream/controller/product/ProductControllerSwagger.java
+++ b/src/main/java/com/app/kream/controller/product/ProductControllerSwagger.java
@@ -4,6 +4,7 @@ import com.app.kream.common.CommonResponse;
 import com.app.kream.service.dto.DetailProductResponse;
 import com.app.kream.service.dto.RecommendProductResponse;
 import com.app.kream.service.dto.ReleaseProductResponse;
+import com.app.kream.service.dto.SearchProductResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -46,4 +47,16 @@ public interface ProductControllerSwagger {
     CommonResponse<RecommendProductResponse> getRecommendProduct(
             @RequestHeader final Long memberId
     );
+
+    @Operation(summary = "검색 상품 조회 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "검색 상품 조회에 성공했습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    CommonResponse<SearchProductResponse> getRecommendProduct(
+            @PathVariable final String findName
+    );
+
+
+
 }

--- a/src/main/java/com/app/kream/controller/product/ProductControllerSwagger.java
+++ b/src/main/java/com/app/kream/controller/product/ProductControllerSwagger.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "상품", description = "상품 관련 API 입니다.")
 public interface ProductControllerSwagger {
@@ -53,10 +54,7 @@ public interface ProductControllerSwagger {
             @ApiResponse(responseCode = "200", description = "검색 상품 조회에 성공했습니다."),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.", content = @Content(schema = @Schema(implementation = CommonResponse.class)))
     })
-    CommonResponse<SearchProductResponse> getRecommendProduct(
-            @PathVariable final String findName
+    CommonResponse<SearchProductResponse> getFindProduct(
+            @RequestParam(value = "findName") String findName
     );
-
-
-
 }

--- a/src/main/java/com/app/kream/domain/Product.java
+++ b/src/main/java/com/app/kream/domain/Product.java
@@ -67,4 +67,8 @@ public class Product extends BaseTimeEntity {
     @Column(nullable = false)
     private String colorBest;
 
+    @Column(nullable = false)
+    private String scrapCount;
+
+
 }

--- a/src/main/java/com/app/kream/exception/SuccessMessage.java
+++ b/src/main/java/com/app/kream/exception/SuccessMessage.java
@@ -16,12 +16,7 @@ public enum SuccessMessage {
     GET_RELEASE_PRODUCT_SUCCESS(HttpStatus.OK.value(), "발매 상품 정보 조회에 성공했습니다."),
     GET_RECOMMEND_PRODUCT_SUCCESS(HttpStatus.OK.value(), "추천 상품 조회에 성공했습니다."),
 
-    /**
-     * 201 CREATED SUCCESS
-     */
-
-
-    ;
+    GET_FIND_PRODUCT_BY_NAME(HttpStatus.OK.value(), "검색 상품 조회에 성공했습니다");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/app/kream/repository/ProductRepository.java
+++ b/src/main/java/com/app/kream/repository/ProductRepository.java
@@ -2,6 +2,12 @@ package com.app.kream.repository;
 
 import com.app.kream.domain.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+@Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
+    List<Product> findByBrandTitleInOrTitleInOrEngTitleIn(String findName);
+    List<Product> findByTitleIn(String titleName);
 }

--- a/src/main/java/com/app/kream/service/ProductService.java
+++ b/src/main/java/com/app/kream/service/ProductService.java
@@ -60,11 +60,15 @@ public class ProductService {
 
         List<Product> products = findLimitCountProduct(5);
         List<JustDropProductResponse> justDropProducts = products.stream()
-                        .map(product -> JustDropProductResponse.of(product, scrapService.existByMemberIdAndProductId(memberId, product.getId())))
+                        .map(product -> JustDropProductResponse.of(
+                                product, scrapService.existByMemberIdAndProductId(
+                                        memberId, product.getId())
+                        ))
                         .toList();
 
         return RecommendProductResponse.of(forYouProducts, justDropProducts);
     }
+
 
     public List<Product> findAllProduct() {
         return productRepository.findAll();
@@ -77,4 +81,18 @@ public class ProductService {
                 .limit(count)
                 .toList();
     }
+
+    public SearchProductResponse findSearchProduct(
+            String findName
+    ) {
+        return SearchProductResponse.of(
+                SearchFindProductResponse.convertForYouProductsToResponses(
+                        productRepository.findByBrandTitleInOrTitleInOrEngTitleIn(findName)
+                ),
+                RelateRecommendProductResponse.convertForYouProductsToResponses(
+                        productRepository.findByTitleIn(findName)
+                )
+        );
+    }
+
 }

--- a/src/main/java/com/app/kream/service/dto/RelateRecommendProductResponse.java
+++ b/src/main/java/com/app/kream/service/dto/RelateRecommendProductResponse.java
@@ -1,0 +1,36 @@
+package com.app.kream.service.dto;
+
+import com.app.kream.domain.Product;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record RelateRecommendProductResponse(
+        String thumbnailUrl,
+        String engTitle,
+        String price,
+        Boolean isFast,
+        String scrapCount
+
+) {
+    public static RelateRecommendProductResponse of(
+            final Product product
+    ) {
+        return new RelateRecommendProductResponse(
+                product.getThumbnailUrl(),
+                product.getBrandTitle(),
+                product.getEngTitle(),
+                product.isFast(),
+                product.getScrapCount()
+        );
+    }
+
+    public static List<RelateRecommendProductResponse> convertForYouProductsToResponses(
+            List<Product> products
+    ) {
+        return products.stream()
+                .map(RelateRecommendProductResponse::of)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/app/kream/service/dto/SearchFindProductResponse.java
+++ b/src/main/java/com/app/kream/service/dto/SearchFindProductResponse.java
@@ -1,0 +1,36 @@
+package com.app.kream.service.dto;
+
+import com.app.kream.domain.Product;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record SearchFindProductResponse(
+        String thumbnailUrl,
+        String brandTitle,
+        String engTitle,
+        String title,
+        String price,
+        String transactionCount
+) {
+    public static SearchFindProductResponse of(
+            final Product product
+    ) {
+        return new SearchFindProductResponse(
+                product.getThumbnailUrl(),
+                product.getBrandTitle(),
+                product.getEngTitle(),
+                product.getTitle(),
+                product.getPrice(),
+                product.getTransactionCount()
+        );
+    }
+
+    public static List<SearchFindProductResponse> convertForYouProductsToResponses(
+            List<Product> products
+    ) {
+        return products.stream()
+                .map(SearchFindProductResponse::of)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/app/kream/service/dto/SearchProductResponse.java
+++ b/src/main/java/com/app/kream/service/dto/SearchProductResponse.java
@@ -1,0 +1,18 @@
+package com.app.kream.service.dto;
+
+import java.util.List;
+
+public record SearchProductResponse(
+        List<SearchFindProductResponse> searchFindProductResponses,
+        List<RelateRecommendProductResponse> relateRecommendProductResponses
+) {
+    public static SearchProductResponse of(
+            List<SearchFindProductResponse> searchFindProductResponses,
+            List<RelateRecommendProductResponse> relateRecommendProductResponses
+    ) {
+        return new SearchProductResponse(
+                searchFindProductResponses,
+                relateRecommendProductResponses
+        );
+    }
+}


### PR DESCRIPTION
## ✨ 해결한 이슈번호
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- closes: #17 

## 📋 요구사항 분석
<!-- 해당 API에 대한 요구사항(사용자 플로우)을/를 설명해주세요 -->
- [ ]  Repository에 상품에 Name으로 찾는 로직 추가
    - 해당 부분은 검색시 상품명,영문명,브랜드명이 들어가는 경우 조회되도록 구현
- [ ] Product를 각각 12개 , 5개로 반환 X -> 더미데이터 테스트 후 진행
    - 해당부분에서 12개, 5개 미만일수도 있기 때문에 테스트 한 후 진행하겠습니다!
- [ ] 형태에 맞는 DTO 추가
    
## 📢 주요 코드 설명
<!-- 해당 PR에서 공유해야하는 부분이나, 특별히 리뷰어가 확인해야하는 코드가 있다면 코드와 함께 공유해주세요 -->
-  검색에 따른 상품 조회 기능 Repository에 추가
-  12개를 보여줄때는 전체검색, 5개는 Title만 포함하도록 구현했습니다! 
https://github.com/NOW-SOPT-APP4-KREAM/KREAM-Server/blob/e7a1ec80c927ec6fb195d4de6f51e6687171139a/src/main/java/com/app/kream/repository/ProductRepository.java#L11-L12

- 12개 Find dto
    - https://github.com/NOW-SOPT-APP4-KREAM/KREAM-Server/blob/e7a1ec80c927ec6fb195d4de6f51e6687171139a/src/main/java/com/app/kream/service/dto/SearchFindProductResponse.java#L8-L36
- 5개 view 연관추천 DTO
    - https://github.com/NOW-SOPT-APP4-KREAM/KREAM-Server/blob/e7a1ec80c927ec6fb195d4de6f51e6687171139a/src/main/java/com/app/kream/service/dto/RelateRecommendProductResponse.java#L8-L36

- ScrapCount가 필요하여 Scrap Entity추가 
![image](https://github.com/NOW-SOPT-APP4-KREAM/KREAM-Server/assets/40743105/55cc0985-eda0-4442-9a05-3c31ec073720)
https://github.com/NOW-SOPT-APP4-KREAM/KREAM-Server/blob/e7a1ec80c927ec6fb195d4de6f51e6687171139a/src/main/java/com/app/kream/domain/Product.java#L70-L71
